### PR TITLE
Updated OS X installation instructions (replaced MacPorts with Homebrew)

### DIFF
--- a/en/01-introduction/01-chapter1.markdown
+++ b/en/01-introduction/01-chapter1.markdown
@@ -77,11 +77,9 @@ There are two ways to install Git on a Mac. The easiest is to use the graphical 
 Insert 18333fig0107.png
 Figure 1-7. Git OS X installer.
 
-The other major way is to install Git via MacPorts (`http://www.macports.org`). If you have MacPorts installed, install Git via
+The other major way is to install Git via Homebrew (`http://brew.sh/`). If you have Homebrew installed, install Git via
 
-	$ sudo port install git-core +svn +doc +bash_completion +gitweb
-
-You don’t have to add all the extras, but you’ll probably want to include +svn in case you ever have to use Git with Subversion repositories (see Chapter 8).
+	$ brew install git
 
 ### Installing on Windows ###
 


### PR DESCRIPTION
Homebrew is now the easiest way to install Unix packages on OS X. Also, `brew install git` is sufficient to get access to `git svn`.
